### PR TITLE
Support Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+  - docker
+  
+before_install:
+- curl -L https://github.com/drone/drone-cli/releases/download/v0.8.5/drone_linux_amd64.tar.gz | tar zx
+- sudo install -t /usr/local/bin drone
+
+script:
+- drone exec


### PR DESCRIPTION
I like the transparency of Travis CI's open builds and logs. We could integrate it with the firmware Slack channel to notify upon failed builds. No pressure to merge this, just a suggestion.

Example build: https://travis-ci.org/emersonian/nycmesh-firmware